### PR TITLE
Bump v0.2.1; Unify auth api fn interface

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,0 +1,1 @@
+NUID_API_KEY=test

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 # NuID SDK for Node.js
 
 [![](https://img.shields.io/npm/v/@nuid/sdk-nodejs?color=green&logo=npm&style=for-the-badge)](https://www.npmjs.com/package/@nuid/sdk-nodejs)
-[![](https://img.shields.io/badge/docs-v0.2.1-blue?style=for-the-badge&logo=read-the-docs)](http://libdocs.s3-website-us-east-1.amazonaws.com/sdk-nodejs/v0.2.1/)
+[![](https://img.shields.io/badge/docs-v0.2.1-blue?style=for-the-badge&logo=read-the-docs)](http://libdocs.s3-website-us-east-1.amazonaws.com/sdk-nodejs/)
 [![](https://img.shields.io/badge/docs-platform-purple?style=for-the-badge&logo=read-the-docs)](https://portal.nuid.io/docs)
 
 This repo provides an npm package for interacting with NuID APIs within Node.js
 applications.
 
 Read the latest [package
-docs](http://libdocs.s3-website-us-east-1.amazonaws.com/sdk-nodejs/v0.2.1/) or
+docs](http://libdocs.s3-website-us-east-1.amazonaws.com/sdk-nodejs/) or
 checkout the [platform docs](https://portal.nuid.io/docs) for API docs, guides,
 video tutorials, and more.
 

--- a/README.md
+++ b/README.md
@@ -36,22 +36,30 @@ yarn add @nuid/sdk-nodejs
 
 Example server endpoint handled by [express](https://expressjs.com).
 
-For a more detailed example visit the [Integrating with NuID](https://portal.nuid.io/docs/guides/integrating-with-nuid) guide and its
-accompanying repository
-[node-example](https://github.com/NuID/node-example/tree/bj/client-server-apps).
+For a more detailed example visit the [Integrating with
+NuID](https://portal.nuid.io/docs/guides/integrating-with-nuid) guide and its
+accompanying [examples repository](https://github.com/NuID/examples/tree/main)
+with a [Node.js + express.js
+example](https://github.com/NuID/examples/blob/daf2a2820e8766871dcf720c02c4e4caa0181544/js-node/src/api.js#L44-L118)
+.
 
 ```javascript
 const express = require('express')
-const nuidApi = require('@nuid/sdk-nodejs')({
+const nuidApi = require('@nuid/sdk-nodejs').default({
   auth: { apiKey: process.env.NUID_API_KEY }
 })
 
 const app = express()
-app.post('/register', async (req, res) => {
-  const body = await nuidApi.auth.credentialCreate(req.body.verifiedCredential)
-  const nuid = body['nu/id']
-  const user = await User.create({ nuid, email, first_name, last_name })
-  res.json({ user }).send(204)
+
+// See links above for more complete examples
+app.post('/register', (req, res) => {
+  return Promise.resolve(req.body.verifiedCredential)
+    .then(nuidApi.auth.credentialCreate)
+    .then(res  => res.parsedBody['nu/id'])
+    .then(nuid => User.create({ nuid, email, first_name, last_name }))
+    .then(user => res.json({ user }).send(201))
+    .catch(err => res.json({ errors: ["Failed to create credential"] }).send(500))
 })
+
 app.listen(process.env.PORT)
 ```

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 # NuID SDK for Node.js
 
 [![](https://img.shields.io/npm/v/@nuid/sdk-nodejs?color=green&logo=npm&style=for-the-badge)](https://www.npmjs.com/package/@nuid/sdk-nodejs)
-[![](https://img.shields.io/badge/docs-v0.1.0-blue?style=for-the-badge&logo=read-the-docs)](http://libdocs.s3-website-us-east-1.amazonaws.com/sdk-nodejs/v0.1.0/)
+[![](https://img.shields.io/badge/docs-v0.2.1-blue?style=for-the-badge&logo=read-the-docs)](http://libdocs.s3-website-us-east-1.amazonaws.com/sdk-nodejs/v0.2.1/)
 [![](https://img.shields.io/badge/docs-platform-purple?style=for-the-badge&logo=read-the-docs)](https://portal.nuid.io/docs)
 
 This repo provides an npm package for interacting with NuID APIs within Node.js
 applications.
 
 Read the latest [package
-docs](http://libdocs.s3-website-us-east-1.amazonaws.com/sdk-nodejs/v0.1.0/) or
+docs](http://libdocs.s3-website-us-east-1.amazonaws.com/sdk-nodejs/v0.2.1/) or
 checkout the [platform docs](https://portal.nuid.io/docs) for API docs, guides,
 video tutorials, and more.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuid/sdk-nodejs",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@nuid/api",
-  "version": "0.1.0",
+  "name": "@nuid/sdk-nodejs",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -110,6 +110,20 @@
         "fastq": "^1.6.0"
       }
     },
+    "@nuid/zk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nuid/zk/-/zk-0.1.1.tgz",
+      "integrity": "sha512-05nk2K0lXNkRMJKny8gEEsVuAl1xz9xkrM55pjvCp6WrOpmYO2WO1nJ5tDWmkbqKrsZBEJUjVURyfJrF+boGkA==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^5.1.1",
+        "brorand": "^1.1.0",
+        "buffer": "^5.6.0",
+        "elliptic": "^6.5.3",
+        "hash.js": "^1.1.7",
+        "scryptsy": "^2.1.0"
+      }
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
@@ -148,6 +162,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.0.tgz",
+      "integrity": "sha512-/Sge3BymXo4lKc31C8OINJgXLaw+7vL1/L1pGiBNpGrBiT8FQiaFpSYV0uhTaG4y78vcMBTMFsWaHDvuD+xGzQ==",
       "dev": true
     },
     "@types/node": {
@@ -194,6 +214,12 @@
         "semver": "^6.3.0",
         "tsutils": "^3.17.1"
       }
+    },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
     },
     "abbrev": {
       "version": "1.1.1",
@@ -288,6 +314,12 @@
         }
       }
     },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
+    },
     "ansi-escapes": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
@@ -335,6 +367,12 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -402,10 +440,22 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
+    "bn.js": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+      "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
       "dev": true
     },
     "boxen": {
@@ -493,6 +543,34 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "cacheable-request": {
       "version": "6.1.0",
@@ -713,6 +791,63 @@
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
       "dev": true
     },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
     "clone-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
@@ -826,6 +961,12 @@
         }
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -873,6 +1014,12 @@
       "requires": {
         "ms": "2.1.2"
       }
+    },
+    "decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -1053,6 +1200,29 @@
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
+    "elliptic": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+          "dev": true
+        }
+      }
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1076,6 +1246,12 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-goat": {
       "version": "2.1.1",
@@ -1397,6 +1573,12 @@
         "path-exists": "^4.0.0"
       }
     },
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -1466,6 +1648,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "get-own-enumerable-property-symbols": {
@@ -1588,6 +1776,12 @@
         "iterall": "^1.2.2"
       }
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
     "handlebars": {
       "version": "4.7.6",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
@@ -1630,6 +1824,33 @@
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true
     },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dev": true,
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
     "html-element-attributes": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/html-element-attributes/-/html-element-attributes-2.2.1.tgz",
@@ -1662,6 +1883,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "ignore": {
       "version": "3.3.10",
@@ -2472,6 +2699,12 @@
         "semver": "^6.0.0"
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -2553,6 +2786,18 @@
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -2575,6 +2820,189 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "mocha": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.0.tgz",
+      "integrity": "sha512-TQqyC89V1J/Vxx0DhJIXlq9gbbL9XFNdeLQ1+JsnZsVaSOV1z3tWfw0qZmQJGQRIfkvZcs7snQnZnOCKoldq1Q==",
+      "dev": true,
+      "requires": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.1",
+        "debug": "4.3.1",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.1.6",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "4.0.0",
+        "log-symbols": "4.0.0",
+        "minimatch": "3.0.4",
+        "ms": "2.1.3",
+        "nanoid": "3.1.20",
+        "serialize-javascript": "5.0.1",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "wide-align": "1.1.3",
+        "workerpool": "6.1.0",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+          "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "log-symbols": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+          "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "mri": {
@@ -2611,6 +3039,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/n-readlines/-/n-readlines-1.0.0.tgz",
       "integrity": "sha512-ISDqGcspVu6U3VKqtJZG1uR55SmNNF9uK0EMq1IvNVVZOui6MW6VR0+pIZhqz85ORAGp+4zW+5fJ/SE7bwEibA==",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
       "dev": true
     },
     "natural-compare": {
@@ -3347,6 +3781,15 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
       "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
     },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -3477,6 +3920,12 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
     "resolve": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
@@ -3559,6 +4008,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "scryptsy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
+      "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==",
+      "dev": true
+    },
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -3578,6 +4033,15 @@
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
+      }
+    },
+    "serialize-javascript": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
       }
     },
     "shebang-command": {
@@ -3685,6 +4149,16 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -3905,6 +4379,20 @@
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
       "dev": true
+    },
+    "ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
     },
     "ts-toolbelt": {
       "version": "6.15.5",
@@ -4274,6 +4762,48 @@
         "isexe": "^2.0.0"
       }
     },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "widest-line": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
@@ -4293,6 +4823,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "workerpool": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
+      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
       "dev": true
     },
     "wrap-ansi": {
@@ -4377,6 +4913,12 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
+    "y18n": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+      "dev": true
+    },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
@@ -4402,6 +4944,59 @@
         "tslib": "^1.10.0",
         "yaml": "^1.7.1"
       }
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true
+    },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+          "dev": true
+        }
+      }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuid/sdk-nodejs",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "SDK for interacting with NuID APIs in Node.js",
   "files": [
     "/dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuid/sdk-nodejs",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "SDK for interacting with NuID APIs in Node.js",
   "files": [
     "/dist",
@@ -18,6 +18,7 @@
     "clean": "tsc --build --clean",
     "doc": "typedoc --includeVersion --readme README.md  --listInvalidSymbolLinks src",
     "format": "prettier-standard --lint --format -- 'src/**/*.ts'",
+    "test": "mocha --require ts-node/register test/**/*_test.js",
     "watch": "npm-watch"
   },
   "repository": {
@@ -43,10 +44,14 @@
     "ramda": "^0.27.1"
   },
   "devDependencies": {
+    "@nuid/zk": "^0.1.1",
+    "@types/mocha": "^8.2.0",
     "@types/node-fetch": "^2.5.8",
     "@types/ramda": "^0.27.36",
+    "mocha": "^8.3.0",
     "npm-watch": "^0.7.0",
     "prettier-standard": "^16.4.1",
+    "ts-node": "^9.1.1",
     "typedoc": "^0.20.19",
     "typescript": "^4.1.3"
   }

--- a/src/http.ts
+++ b/src/http.ts
@@ -7,6 +7,12 @@ import { config, APIConfig, APIName } from './config'
 import fetch, { Response } from 'node-fetch'
 import * as R from 'ramda'
 
+export type ParsedJSON<Body> = {
+  parsedBody: Body
+}
+
+export type SDKResponse<T> = Response & ParsedJSON<T>
+
 const apiConfig: (api: APIName) => Promise<APIConfig> = api =>
   new Promise((resolve, reject) => {
     if (R.has(api, config)) {
@@ -16,20 +22,32 @@ const apiConfig: (api: APIName) => Promise<APIConfig> = api =>
     }
   })
 
+async function bodyFromJSON<T>(res: Response): Promise<T> {
+  return res.text().then((body: string) => (R.isEmpty(body) ? {} : JSON.parse(body)))
+}
+
+async function consumeBody<T>(res: SDKResponse<T>): Promise<SDKResponse<T>> {
+  return bodyFromJSON(res).then(body => {
+    res.parsedBody = body as T
+    return res
+  })
+}
+
 /**
  * Perform a GET request against a named NuID API.
- * @typeParam ResponseBody - The type of the response body after JSON deserialization.
+ * @typeParam ResponseBodyT - The type of the response body after JSON deserialization.
  * @param api - The name of the api configuration to use. @see [[config.APIName]]
  * @param path - The path portion of the URI.
- * @returns - The specified `ResponseBody` object, or the
+ * @returns - For "ok" responses, the node-fetch 
  *   [`fetch` Response](https://www.npmjs.com/package/node-fetch#class-response) object
- *   if the request was not `res.ok`.
+ *   with a `parsedBody` key populated to the parsed body of the response.
+ *   Non-"ok" responses are `Promise.reject(res)`ed.
  */
-export const get: <ResponseBody>(
+export async function get<ResponseBodyT>(
   api: APIName,
   path: string
-) => Promise<ResponseBody> = (api, path) =>
-  apiConfig(api)
+): Promise<SDKResponse<ResponseBodyT>> {
+  return apiConfig(api)
     .then(cfg =>
       fetch(`${cfg.rootUrl}${path}`, {
         method: 'GET',
@@ -39,29 +57,28 @@ export const get: <ResponseBody>(
         }
       })
     )
-    .then(res => (res.ok ? res.json() : Promise.reject(res)))
-
-const bodyFromJSON: <ResponseBody>(
-  res: Response
-) => Promise<ResponseBody> = res =>
-  res.text().then((body: string) => (R.isEmpty(body) ? {} : JSON.parse(body)))
+    .then(res => consumeBody<ResponseBodyT>(res as SDKResponse<ResponseBodyT>))
+    .then(res => (res.ok ? res : Promise.reject(res)))
+}
 
 /**
  * Perform a POST request against a named NuID API.
- * @typeParam ResponseBody - The type of the response body after JSON deserialization.
+ * @typeParam RequestBodyT - The type of the request body after JSON deserialization.
+ * @typeParam ResponseBodyT - The type of the response body after JSON deserialization.
  * @param api - The name of the api configuration to use. @see [[config.APIName]]
  * @param path - The path portion of the URI.
  * @param body - The body of the request to be JSON serialized.
- * @returns - The specified `ResponseBody` object, or the
+ * @returns - For "ok" responses, the node-fetch 
  *   [`fetch` Response](https://www.npmjs.com/package/node-fetch#class-response) object
- *   if the request was not `res.ok`.
+ *   with a `parsedBody` key populated to the parsed body of the response.
+ *   Non-"ok" responses are `Promise.reject(res)`ed.
  */
-export const post: <RequestBody, ResponseBody>(
+export async function post<RequestBodyT, ResponseBodyT>(
   api: APIName,
   path: string,
-  body: RequestBody
-) => Promise<ResponseBody> = (api, path, body) =>
-  apiConfig(api)
+  body: RequestBodyT
+): Promise<SDKResponse<ResponseBodyT>> {
+  return apiConfig(api)
     .then(cfg =>
       fetch(`${cfg.rootUrl}${path}`, {
         method: 'POST',
@@ -73,4 +90,6 @@ export const post: <RequestBody, ResponseBody>(
         }
       })
     )
-    .then(res => (res.ok ? bodyFromJSON(res) : Promise.reject(res)))
+    .then(res => consumeBody<ResponseBodyT>(res as SDKResponse<ResponseBodyT>))
+    .then(res => (res.ok ? res : Promise.reject(res)))
+}

--- a/src/http.ts
+++ b/src/http.ts
@@ -7,10 +7,25 @@ import { config, APIConfig, APIName } from './config'
 import fetch, { Response } from 'node-fetch'
 import * as R from 'ramda'
 
-export type ParsedJSON<Body> = {
-  parsedBody: Body
+/**
+ * @typeParam T - The type of the expected response body for valid responses.
+ */
+export type ParsedJSON<T> = {
+  /**
+   * JSON-parsed object of type `T`, for use with specifying HTTP response bodies.
+   */
+  parsedBody: T
 }
 
+/**
+ * Union of [`fetch` Response](https://www.npmjs.com/package/node-fetch#class-response)
+ * type and [[ParsedJSON]].
+ *
+ * Provides a [[parsedBody]] attribute alongside the regular response object
+ * for working with the JSON-parsed body.
+ *
+ * @typeParam T - The type of the expected response body for valid responses.
+ */
 export type SDKResponse<T> = Response & ParsedJSON<T>
 
 const apiConfig: (api: APIName) => Promise<APIConfig> = api =>
@@ -27,10 +42,29 @@ async function bodyFromJSON<T>(res: Response): Promise<T> {
 }
 
 async function consumeBody<T>(res: SDKResponse<T>): Promise<SDKResponse<T>> {
-  return bodyFromJSON(res).then(body => {
-    res.parsedBody = body as T
-    return res
-  })
+  return bodyFromJSON(res).then(R.assoc('parsedBody', R.__, res))
+}
+
+function getOpts(cfg: APIConfig): Object {
+  return {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      'X-API-Key': cfg.apiKey
+    }
+  }
+}
+
+function postOpts<T>(cfg: APIConfig, body: T): Object {
+  return {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-API-Key': cfg.apiKey
+    }
+  }
 }
 
 /**
@@ -38,25 +72,20 @@ async function consumeBody<T>(res: SDKResponse<T>): Promise<SDKResponse<T>> {
  * @typeParam ResponseBodyT - The type of the response body after JSON deserialization.
  * @param api - The name of the api configuration to use. @see [[config.APIName]]
  * @param path - The path portion of the URI.
- * @returns - For "ok" responses, the node-fetch 
- *   [`fetch` Response](https://www.npmjs.com/package/node-fetch#class-response) object
- *   with a `parsedBody` key populated to the parsed body of the response.
- *   Non-"ok" responses are `Promise.reject(res)`ed.
+ * @returns - The [`fetch`
+ *   Response](https://www.npmjs.com/package/node-fetch#class-response) object
+ *   with a [[parsedBody]] attribute of type `ResponseBodyT`.
+ * @throws The [`fetch`
+ *   Response](https://www.npmjs.com/package/node-fetch#class-response) object
+ *   will be thrown `if (!res.ok)`. The [[parsedBody]] attribute may be set with
+ *   an object of type `ResponseBodyT`.
  */
 export async function get<ResponseBodyT>(
   api: APIName,
   path: string
 ): Promise<SDKResponse<ResponseBodyT>> {
   return apiConfig(api)
-    .then(cfg =>
-      fetch(`${cfg.rootUrl}${path}`, {
-        method: 'GET',
-        headers: {
-          Accept: 'application/json',
-          'X-API-Key': cfg.apiKey
-        }
-      })
-    )
+    .then(cfg => fetch(`${cfg.host}${path}`, getOpts(cfg)))
     .then(res => consumeBody<ResponseBodyT>(res as SDKResponse<ResponseBodyT>))
     .then(res => (res.ok ? res : Promise.reject(res)))
 }
@@ -68,10 +97,13 @@ export async function get<ResponseBodyT>(
  * @param api - The name of the api configuration to use. @see [[config.APIName]]
  * @param path - The path portion of the URI.
  * @param body - The body of the request to be JSON serialized.
- * @returns - For "ok" responses, the node-fetch 
- *   [`fetch` Response](https://www.npmjs.com/package/node-fetch#class-response) object
- *   with a `parsedBody` key populated to the parsed body of the response.
- *   Non-"ok" responses are `Promise.reject(res)`ed.
+ * @returns - The [`fetch`
+ *   Response](https://www.npmjs.com/package/node-fetch#class-response) object
+ *   with a [[parsedBody]] attribute of type `ResponseBodyT`.
+ * @throws The [`fetch`
+ *   Response](https://www.npmjs.com/package/node-fetch#class-response) object
+ *   will be thrown `if (!res.ok)`. The [[parsedBody]] attribute may be set with
+ *   an object of type `ResponseBodyT`.
  */
 export async function post<RequestBodyT, ResponseBodyT>(
   api: APIName,
@@ -79,17 +111,7 @@ export async function post<RequestBodyT, ResponseBodyT>(
   body: RequestBodyT
 ): Promise<SDKResponse<ResponseBodyT>> {
   return apiConfig(api)
-    .then(cfg =>
-      fetch(`${cfg.rootUrl}${path}`, {
-        method: 'POST',
-        body: JSON.stringify(body),
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-          'X-API-Key': cfg.apiKey
-        }
-      })
-    )
+    .then(cfg => fetch(`${cfg.host}${path}`, postOpts(cfg, body)))
     .then(res => consumeBody<ResponseBodyT>(res as SDKResponse<ResponseBodyT>))
     .then(res => (res.ok ? res : Promise.reject(res)))
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 /**
- *
  * @module index
  */
 
@@ -7,27 +6,40 @@ import * as auth from './api/auth'
 import setConfig, { Config } from './config'
 
 export interface ConfiguredAPIs {
-  auth: auth.IAuthAPI
+  auth: auth.AuthAPI
   config: Config
 }
 
 /**
  * NuID API Interface
+ * 
+ * Example server endpoint handled by [express](https://expressjs.com).
+ *
+ * For a more detailed example visit the [Integrating with
+ * NuID](https://portal.nuid.io/docs/guides/integrating-with-nuid) guide and its
+ * accompanying [examples repository](https://github.com/NuID/examples/tree/main)
+ * with a [Node.js + express.js
+ * example](https://github.com/NuID/examples/blob/daf2a2820e8766871dcf720c02c4e4caa0181544/js-node/src/api.js#L44-L118)
  *
  * @example
  * ```javascript
  * const express = require('express')
- * const nuidApi = require('@nuid/sdk-nodejs')({
+ * const nuidApi = require('@nuid/sdk-nodejs').default({
  *   auth: { apiKey: process.env.NUID_API_KEY }
  * })
  * 
  * const app = express()
- * app.post('/register', async (req, res) => {
- *   const body = await nuidApi.auth.credentialCreate(req.body.verifiedCredential)
- *   const nuid = body['nu/id']
- *   const user = await User.create({ nuid, email, first_name, last_name })
- *   res.json({ user }).send(204)
+ * 
+ * // See links above for more complete examples
+ * app.post('/register', (req, res) => {
+ *   return Promise.resolve(req.body.verifiedCredential)
+ *     .then(nuidApi.auth.credentialCreate)
+ *     .then(res  => res.parsedBody['nu/id'])
+ *     .then(nuid => User.create({ nuid, email, first_name, last_name }))
+ *     .then(user => res.json({ user }).send(201))
+ *     .catch(err => res.json({ errors: ["Failed to create credential"] }).send(500))
  * })
+ * 
  * app.listen(process.env.PORT)
  * ```
  */

--- a/test/api/auth_test.js
+++ b/test/api/auth_test.js
@@ -1,0 +1,79 @@
+const assert = require('assert')
+const R = require('ramda')
+const sdk = require('../../src/index').default
+const Zk = require('@nuid/zk')
+const { Config } = require('../../src/config')
+
+const isPresent = R.pathSatisfies(R.compose(R.complement(R.isEmpty), R.complement(R.isNil)))
+const decodeClaims = R.pipe(
+  R.split('.'),
+  parts => parts[1],
+  encoded => Buffer.from(encoded, 'base64'),
+  rawClaims => JSON.parse(rawClaims)
+)
+
+describe('api/auth', () => {
+
+  it('should fail on invalid configuration', () => {
+    const badConfigs = [
+      { auth: {} },
+      { auth: {apiKey: null} },
+      { auth: {apiKey: undefined} },
+      { auth: {apiKey: ''} },
+      { auth: {apiKey: '123', host: null} },
+      { auth: {apiKey: '123', host: undefined} },
+      { auth: {apiKey: '123', host: ''} },
+      { auth: {apiKey: '', host: ''} }
+    ]
+    
+    R.forEach(() => {
+      assert.throws(badConfig => {
+        sdk(badConfig)
+      }, badConfigs)
+    })
+  })
+
+  it('should configure the api key and host', () => {
+    const config = sdk({ auth: {
+      apiKey: 'api key test',
+      host: 'host test'
+    }}).config
+    assert.equal('api key test', config.auth.apiKey, 'apiKey is not present')
+    assert.equal('host test', config.auth.host, 'apiKey is not present')
+  })
+
+  it('test roundtrip', () => {
+    const { auth } = sdk({ auth: {
+      apiKey: 'ACrED3gWyu7wBVFmXJoZB43aog1G07Kq86qsYI03',
+      host: 'https://auth.stage-coach.io'
+    }})
+
+    const secret = "my secret password of doom"
+
+    return Promise
+      .resolve(Zk.verifiableFromSecret(secret))
+      .then(auth.credentialCreate)
+      .then (res => {
+        assert.equal(res.status, 201, `credentialCreate failed with ${res.status} ${res.parsedBody}`)
+        return res.parsedBody['nu/id']
+      })
+      .then(auth.credentialGet)
+      .then(res => {
+        assert.equal(res.status, 200, `credentialGet failed with ${res.status} ${res.parsedBody}`)
+        return res.parsedBody['nuid/credential']
+      })
+      .then(auth.challengeGet)
+      .then(res => {
+        assert.equal(res.status, 201, `challengeGet failed with ${res.status} ${res.parsedBody}`)
+        return res.parsedBody['nuid.credential.challenge/jwt']
+      })
+      .then(challengeJWT => {
+        const claims = decodeClaims(challengeJWT)
+        const proof = Zk.proofFromSecretAndChallenge(secret, claims)
+        return auth.challengeVerify(challengeJWT, proof)
+      })
+      .then(res => {
+        assert.equal(res.status, 200, `challengeVerify failed with ${res.status} ${res.parsedBody}`)
+      })
+  })
+})

--- a/test/api/auth_test.js
+++ b/test/api/auth_test.js
@@ -44,7 +44,7 @@ describe('api/auth', () => {
 
   it('test roundtrip', () => {
     const { auth } = sdk({ auth: {
-      apiKey: 'ACrED3gWyu7wBVFmXJoZB43aog1G07Kq86qsYI03',
+      apiKey: process.env.NUID_API_KEY,
       host: 'https://auth.stage-coach.io'
     }})
 


### PR DESCRIPTION
Per [Timothy Sankara](https://nuid-community.slack.com/archives/C015A65P878/p1613393980003600):

> I seem to get some confusing responses from `nuidApi.auth.challengeVerify(challengeJwt, proof)`.
> I get `{verified: false}` as the response from the correct user credentials.
> However, i get an error : `status: 400, statusText: 'Bad Request'` upon using incorrect user credentials.
>   1. Is `{verified: false}` the expected behavior for a verified login?
>   2. And does catching the error from the incorrect credentials response the correct and expected response from it?

Previous to this release the challengeVerify endpoint introduced and
faux-response body `{verified: true|false}` which isn't in line with
the way the endpoint returns data (without a body)

What's worse, the promise resolved to _either_ the parsed body on
"success" or the promise was rejected with the `node-fetch` response
object.

This release adds a `parsedBody` prop to the `node-fetch` response
object, and always returns it in either success or failure scenarios.
The `parsedBody` prop _may_ be present in the failure case, depending
on where the failure occured in the promise chain.

All documentation has been updated to reflect the above changes.

```javascript
const verify = (challengeJWT, proof) =>
  return api.challengeVerify(challengeJWT, proof)
    .then(res => {
      // no need to check res.ok on any endpoint calls, since we
      // reject with the response `if (!res.ok)`

      // `res.parsedBody` is an empty object for challengeVerify,
      // but it will be populated for the other endpoints
      console.log(res.parsedBody) 
    })
    .catch(res => console.error(`verification failed with status ${res.status}`))
```

Or if you prefer `async`/`await`:

```javascript
async function verify(challengeJWT, proof) {
  try {
    const res = await api.challengeVerify(challengeJWT, proof)
    console.log(res.parsedBody) 
  } catch (res) {
    console.error(`verification failed with status ${res.status}`)
  }
}
```